### PR TITLE
fix: wait for IMAGE container processing in carousel posts

### DIFF
--- a/src/tools/threads/publishing.ts
+++ b/src/tools/threads/publishing.ts
@@ -156,9 +156,7 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
           if (item.alt_text) params.alt_text = item.alt_text;
           const { data: child } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
           const childId = (child as { id: string }).id;
-          if (item.type === "VIDEO") {
-            await waitForThreadsContainer(client, childId);
-          }
+          await waitForThreadsContainer(client, childId);
           childIds.push(childId);
         }
         const carouselParams: Record<string, unknown> = {


### PR DESCRIPTION
## Summary

- Carousel publishing (`threads_publish_carousel`) fails for IMAGE-only carousels with error `4279004` ("carousel child items are invalid or expired")
- Root cause: `waitForThreadsContainer()` was only called for VIDEO items, not IMAGE items
- The [Meta Threads API docs](https://developers.facebook.com/docs/threads/posts#carousel-posts) recommend waiting for all media containers to finish processing before publishing
- Fix: call `waitForThreadsContainer()` for all carousel child items regardless of type

## Test

Tested with a 2-image carousel - published successfully after applying this fix. Previously failed every time.

Fixes #1