### PR TITLE
fix: remove unsupported Threads API fields and metrics

### DIFF
--- a/src/tools/threads/insights.ts
+++ b/src/tools/threads/insights.ts
@@ -9,11 +9,11 @@ export function registerThreadsInsightTools(server: McpServer, client: MetaClien
     "Get insights/analytics for a specific Threads post (views, likes, replies, reposts, quotes, clicks).",
     {
       post_id: z.string().describe("Threads post ID"),
-      metric: z.string().optional().describe("Comma-separated metrics (default: views,likes,replies,reposts,quotes,clicks)"),
+      metric: z.string().optional().describe("Comma-separated metrics (default: views,likes,replies,reposts,quotes)"),
     },
     async ({ post_id, metric }) => {
       try {
-        const m = metric || "views,likes,replies,reposts,quotes,clicks";
+        const m = metric || "views,likes,replies,reposts,quotes";
         const { data, rateLimit } = await client.threads("GET", `/${post_id}/insights`, { metric: m });
         return { content: [{ type: "text", text: JSON.stringify({ ...data as object, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {
@@ -27,7 +27,7 @@ export function registerThreadsInsightTools(server: McpServer, client: MetaClien
     "threads_get_user_insights",
     "Get account-level Threads insights (views, likes, replies, reposts, quotes, clicks, followers, follower demographics).",
     {
-      metric: z.string().describe("Comma-separated metrics: views,likes,replies,reposts,quotes,clicks,followers_count,follower_demographics"),
+      metric: z.string().describe("Comma-separated metrics: views,likes,replies,reposts,quotes,followers_count,follower_demographics"),
       since: z.string().optional().describe("Start date (Unix timestamp)"),
       until: z.string().optional().describe("End date (Unix timestamp)"),
     },

--- a/src/tools/threads/media.ts
+++ b/src/tools/threads/media.ts
@@ -17,7 +17,7 @@ export function registerThreadsMediaTools(server: McpServer, client: MetaClient)
     async ({ limit, since, until, after, before }) => {
       try {
         const params: Record<string, unknown> = {
-          fields: "id,media_product_type,media_type,media_url,permalink,text,timestamp,shortcode,is_quote_post,has_replies,reply_audience,topic_tag,link_attachment_url,poll_attachment,gif_attachment,alt_text",
+          fields: "id,media_product_type,media_type,media_url,permalink,text,timestamp,shortcode,is_quote_post,has_replies,reply_audience,topic_tag,link_attachment_url,poll_attachment,alt_text",
         };
         if (limit) params.limit = limit;
         if (since) params.since = since;
@@ -42,7 +42,7 @@ export function registerThreadsMediaTools(server: McpServer, client: MetaClient)
     },
     async ({ post_id, fields }) => {
       try {
-        const f = fields || "id,media_product_type,media_type,media_url,permalink,text,timestamp,shortcode,is_quote_post,has_replies,reply_audience,topic_tag,link_attachment_url,poll_attachment,gif_attachment,alt_text";
+        const f = fields || "id,media_product_type,media_type,media_url,permalink,text,timestamp,shortcode,is_quote_post,has_replies,reply_audience,topic_tag,link_attachment_url,poll_attachment,alt_text";
         const { data, rateLimit } = await client.threads("GET", `/${post_id}`, { fields: f });
         return { content: [{ type: "text", text: JSON.stringify({ ...data as object, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {

--- a/src/tools/threads/publishing.ts
+++ b/src/tools/threads/publishing.ts
@@ -46,7 +46,7 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
           params.gif_attachment = JSON.stringify({ gif_id, provider: gif_provider });
         }
         if (alt_text) params.alt_text = alt_text;
-        if (is_spoiler) params.is_spoiler_media = true;
+        if (is_spoiler) params.is_spoiler = true;
         const { data: container } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
         const containerId = (container as { id: string }).id;
         const { data, rateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads_publish`, {
@@ -80,7 +80,7 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
         if (topic_tag) params.topic_tag = topic_tag;
         if (quote_post_id) params.quote_post_id = quote_post_id;
         if (alt_text) params.alt_text = alt_text;
-        if (is_spoiler) params.is_spoiler_media = true;
+        if (is_spoiler) params.is_spoiler = true;
         const { data: container } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
         const containerId = (container as { id: string }).id;
         const { data, rateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads_publish`, {
@@ -114,7 +114,7 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
         if (topic_tag) params.topic_tag = topic_tag;
         if (quote_post_id) params.quote_post_id = quote_post_id;
         if (alt_text) params.alt_text = alt_text;
-        if (is_spoiler) params.is_spoiler_media = true;
+        if (is_spoiler) params.is_spoiler = true;
         const { data: container } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
         const containerId = (container as { id: string }).id;
         await waitForThreadsContainer(client, containerId);
@@ -223,7 +223,7 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
     async () => {
       try {
         const { data, rateLimit } = await client.threads("GET", `/${client.threadsUserId}/threads_publishing_limit`, {
-          fields: "quota_usage,config",
+          fields: "quota_usage",
         });
         return { content: [{ type: "text", text: JSON.stringify({ ...data as object, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {

--- a/src/tools/threads/replies.ts
+++ b/src/tools/threads/replies.ts
@@ -16,7 +16,7 @@ export function registerThreadsReplyTools(server: McpServer, client: MetaClient)
     async ({ post_id, reverse, limit, after }) => {
       try {
         const params: Record<string, unknown> = {
-          fields: "id,text,username,permalink,timestamp,media_type,media_url,has_replies,hide_status,is_verified,profile_picture_url",
+          fields: "id,text,username,permalink,timestamp,media_type,media_url,has_replies,hide_status",
         };
         if (reverse !== undefined) params.reverse = reverse;
         if (limit) params.limit = limit;


### PR DESCRIPTION
## Summary

Fixes #7 — Several Threads tools pass fields/metrics that the Threads API v1.0 does not support, causing 500 errors.

### Changes (4 files, 10 lines changed)

**insights.ts** — Remove `clicks` from default metrics
- `clicks` is not a supported metric for Threads post/user insights
- Default changed to `views,likes,replies,reposts,quotes`

**media.ts** — Remove `gif_attachment` from default fields
- `gif_attachment` causes `THApiException: nonexisting field` (500)
- Affects both `threads_get_posts` and `threads_get_post`

**publishing.ts** — Two fixes
- `is_spoiler_media` → `is_spoiler` (correct Threads API parameter name, 3 occurrences)
- Remove `config` from `threads_get_publishing_limit` fields (only `quota_usage` is supported)

**replies.ts** — Remove unsupported reply fields
- `is_verified` and `profile_picture_url` are not supported for reply objects

### Testing

All changes tested against live Threads API v1.0:
- `threads_get_post_insights`: ✅ Returns views/likes/replies/reposts/quotes
- `threads_get_post`: ✅ Returns full post details
- `threads_get_posts`: ✅ Returns post list
- `threads_get_publishing_limit`: ✅ Returns quota_usage
- `threads_get_replies`: ✅ Returns reply data
- `threads_publish_text`: ✅ Creates and publishes post